### PR TITLE
deps: relax urllib3 upper bound to <3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 1.25.3, < 3.0.0
 pydantic >= 2
 typing-extensions >= 4.14.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ NAME = "unicourt"
 VERSION = "1.1.1"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 2.1.0",
+    "urllib3 >= 1.25.3, < 3.0.0",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.14.1",


### PR DESCRIPTION
## Summary
Relax the `urllib3` upper bound from `<2.1.0` to `<3.0.0`.

## Motivation
The current `<2.1.0` constraint blocks consumers that need `urllib3>=2.6.0`.

## Changes
- `setup.py`: `urllib3 >= 1.25.3, < 2.1.0` -> `urllib3 >= 1.25.3, < 3.0.0`
- `requirements.txt`: same

## Notes
- Packaging-only change; no runtime behavior changes.
- Related issue: https://github.com/UniCourt/enterprise-api-py-sdk/issues/25

(Your README mentions targeting `dev-1.1.x`, but that branch does not appear to exist on the repo at the moment, so this PR targets `main`.)
